### PR TITLE
Add autoload package

### DIFF
--- a/autoload/autoload.go
+++ b/autoload/autoload.go
@@ -1,0 +1,15 @@
+package autoload
+
+import (
+	"mime"
+
+	"github.com/GitbookIO/mimedb"
+)
+
+func init() {
+	for ext, mimeType := range mimedb.DB {
+		if err := mime.AddExtensionType("."+ext, mimeType.ContentType); err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
This package make easy to autoregister the mimes on the Go's [mime package](https://golang.org/pkg/mime/#AddExtensionType).

``` go
package main

import (
    "fmt"
    "mime"

    _ "github.com/GitbookIO/mimedb/autoload"
)

func main() {
    fmt.Println(mime.TypeByExtension(".exe")) // application/x-msdownload
}
```
